### PR TITLE
FIXED: User_id not save while address update

### DIFF
--- a/app/controllers/spree/addresses_controller.rb
+++ b/app/controllers/spree/addresses_controller.rb
@@ -16,6 +16,7 @@ class Spree::AddressesController < Spree::BaseController
       new_address = @address.clone
       new_address.attributes = params[:address]
       @address.update_attribute(:deleted_at, Time.now)
+      @address.user_id = current_user.id
       if new_address.save
         flash[:notice] = I18n.t(:successfully_updated, :resource => I18n.t(:address))
       end


### PR DESCRIPTION
Hi,

I've observed an issue that user_id was set to NULL when updating address from /account view. I have fixed that by implicitely setting up user_id to current_user.id in the controller.

I hope it will be helpful.
