### PR TITLE
make user_id and deleted_at accessible

### DIFF
--- a/app/models/spree/address_decorator.rb
+++ b/app/models/spree/address_decorator.rb
@@ -1,6 +1,8 @@
 Spree::Address.class_eval do
   belongs_to :user
 
+  attr_accessible :user_id, :deleted_at
+
   def self.required_fields
     validator = Spree::Address.validators.find{|v| v.kind_of?(ActiveModel::Validations::PresenceValidator)}
     validator ? validator.attributes : []


### PR DESCRIPTION
This fixes support Rails with whitelist based attributes. Otherwise
it tells that `user_id` and `deleted_at` are not mass-assignable when
cloning the address in `Spree::AddressesController#edit`.

Hello, do I need to add some tests? `address_spec` is empty at the moment.

Ciao
