### PR TITLE
Fix: Only show state field if config requires it

### DIFF
--- a/app/views/spree/addresses/_form.html.erb
+++ b/app/views/spree/addresses/_form.html.erb
@@ -2,8 +2,10 @@
   <% if field == "country" %>
     <%= address_form.label :country_id, t(field, :scope => [:activerecord, :attributes, :address]) %><span class="req">*</span><br />
     <span><%= address_form.collection_select :country_id, available_countries, :id, :name, {}, {:class => 'required'} %></span>
-  <% elsif field == "state" && Spree::Config[:address_requires_state] %>
-    <%= address_field(address_form, :state, address_name) { address_state(address_form, address.country) } %>
+  <% elsif field == "state" %>
+    <% if Spree::Config[:address_requires_state] %>
+      <%= address_field(address_form, :state, address_name) { address_state(address_form, address.country) } %>
+    <% end %>
   <% else %>
     <%= address_field(address_form, field.to_sym, address_name) %>
   <% end %>


### PR DESCRIPTION
Previously, if Spree::Config[:address_requires_state] was set to false, the else branch of the if-else construct would wrongly be triggered, displaying the state field and potentially leading to errors. Now the state field is only shown if the config flag is actually set to true.
