### PR TITLE
State field not available in checkout

### DIFF
--- a/app/views/spree/addresses/_form.html.erb
+++ b/app/views/spree/addresses/_form.html.erb
@@ -3,7 +3,7 @@
   <% if field == "country" %>
     <p class="field" id="<%= country_id %>">
     <%= address_form.label :country_id, t(field, :scope => [:activerecord, :attributes, :address]) %><span class="req">*</span><br />
-    <span id="<%= country_id %>"><%= address_form.collection_select :country_id, available_countries, :id, :name, {}, {:class => 'required'} %></span>
+    <span id="<%= country_id %>-selection"><%= address_form.collection_select :country_id, available_countries, :id, :name, {}, {:class => 'required'} %></span>
   <% elsif field == "state" && Spree::Config[:address_requires_state] %>
     <%= address_field(address_form, :state, address_name) { address_state(address_form, address.country) } %>
   <% else %>


### PR DESCRIPTION
On Spree 1.3.1, using this extension will cause the state field not to show up when checking out.  To repro - create a new spree store with 1.3.1, install this extension, then add a product and checkout as guest.  The State field will be missing, and you cannot continue checkout.

This was interacting with the update_state js function in spree_core; changing the name to the expected name makes the base script work again.
