### PR TITLE
Fix issue when edit address

### DIFF
--- a/app/views/spree/addresses/_form.html.erb
+++ b/app/views/spree/addresses/_form.html.erb
@@ -1,4 +1,4 @@
-<% country_id = address_type == 'billing' ? 'bcountry' : 'scountry' %>
+<% country_id = defined?(address_type) ? (address_type == 'billing' ? 'bcountry' : 'scountry') : 'country' %>
 <% ADDRESS_FIELDS.each do |field| %>
   <% if field == "country" %>
     <p class="field" id="<%= country_id %>">


### PR DESCRIPTION
Repro steps for issue:
1. Create new spree 1.3.1 store, add this extension
2. Sign in, make new order, and checkout
3. Go to My Account page
4. Click 'edit' for your stored address

Throws exception, this fix addresses it.
