### PR TITLE
Fix engine initializer token

### DIFF
--- a/lib/spree_address_book.rb
+++ b/lib/spree_address_book.rb
@@ -5,7 +5,7 @@ module Spree
     class Engine < Rails::Engine
       engine_name 'spree_address_book'
       
-      initializer "spree.advanced_cart.environment", :before => :load_config_initializers do |app|
+      initializer "spree.address_book.environment", :before => :load_config_initializers do |app|
         Spree::AddressBook::Config = Spree::AddressBookConfiguration.new
       end
       


### PR DESCRIPTION
This looks like it was copied from spree_advanced_cart code. It could be a problem if you want your engines initializer to load before or after this specific initializer.
