### PR TITLE
Don't depent on Spree::Auth::Devise

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,9 +1,9 @@
 source "http://rubygems.org"
 
+gemspec
+
 gem 'spree', '~> 3.0.0.rc'
 gem 'spree_auth_devise', :git => 'git://github.com/spree/spree_auth_devise', :branch => '3-0-stable'
-
-gemspec
 
 group :test do
   gem 'sass-rails'
@@ -11,4 +11,3 @@ group :test do
   gem 'pry-nav'
   gem 'selenium-webdriver'
 end
-

--- a/app/overrides/add_address_book_to_my_account.rb
+++ b/app/overrides/add_address_book_to_my_account.rb
@@ -1,7 +1,9 @@
-Deface::Override.new(
-  :virtual_path => "spree/users/show",
-  :name => "address_book_account_my_orders",
-  :insert_after => "[data-hook='account_my_orders'], #account_my_orders[data-hook]",
-  :partial => "spree/users/addresses",
-  :disabled => false
-)
+if Object.const_defined?("Spree::User")
+  Deface::Override.new(
+    :virtual_path => "spree/users/show",
+    :name => "address_book_account_my_orders",
+    :insert_after => "[data-hook='account_my_orders'], #account_my_orders[data-hook]",
+    :partial => "spree/users/addresses",
+    :disabled => false
+  )
+end

--- a/app/overrides/add_address_book_to_my_account.rb
+++ b/app/overrides/add_address_book_to_my_account.rb
@@ -1,4 +1,4 @@
-if Object.const_defined?("Spree::User")
+if (Object.const_get("Spree::User") rescue false)
   Deface::Override.new(
     :virtual_path => "spree/users/show",
     :name => "address_book_account_my_orders",

--- a/spree_address_book.gemspec
+++ b/spree_address_book.gemspec
@@ -17,8 +17,7 @@ Gem::Specification.new do |s|
   s.requirements << 'none'
 
   s.add_dependency('spree_core', '~> 3.0.0.rc')
-  s.add_dependency('spree_auth_devise')
-  
+
   s.add_development_dependency('rspec-rails', '2.14.0')
   s.add_development_dependency('sqlite3')
   s.add_development_dependency('capybara', '~> 2.1')


### PR DESCRIPTION
It is not really needed in runtime, except in the test app.

This makes it possible to use this extension also for your custom user class.