### PR TITLE
Fix the override of permitted attributes

### DIFF
--- a/app/controllers/spree/addresses_controller.rb
+++ b/app/controllers/spree/addresses_controller.rb
@@ -58,18 +58,8 @@ class Spree::AddressesController < Spree::StoreController
   end
 
   private
-    def address_params
-      params[:address].permit(:address,
-                              :firstname,
-                              :lastname,
-                              :address1,
-                              :address2,
-                              :city,
-                              :state_id,
-                              :zipcode,
-                              :country_id,
-                              :phone
-                             )
-    end
-end
 
+  def address_params
+    params[:address].permit(Spree::PermittedAttributes.address_attributes)
+  end
+end

--- a/app/models/spree/address_decorator.rb
+++ b/app/models/spree/address_decorator.rb
@@ -1,7 +1,3 @@
-(Spree::PermittedAttributes.class_variable_get("@@address_attributes") << [
-  :user_id, :deleted_at
-]).flatten!
-
 Spree::Address.class_eval do
   belongs_to :user, :class_name => Spree.user_class.to_s
 
@@ -10,14 +6,14 @@ Spree::Address.class_eval do
       v.kind_of?(ActiveModel::Validations::PresenceValidator) ? v.attributes : []
     end.flatten
   end
-  
+
   # TODO: look into if this is actually needed. I don't want to override methods unless it is really needed
   # can modify an address if it's not been used in an order
   def same_as?(other)
     return false if other.nil?
     attributes.except('id', 'updated_at', 'created_at', 'user_id') == other.attributes.except('id', 'updated_at', 'created_at', 'user_id')
   end
-  
+
   # can modify an address if it's not been used in an completed order
   def editable?
     new_record? || (shipments.empty? && Spree::Order.complete.where("bill_address_id = ? OR ship_address_id = ?", self.id, self.id).count == 0)

--- a/config/initializers/address_fields.rb
+++ b/config/initializers/address_fields.rb
@@ -1,1 +1,17 @@
-ADDRESS_FIELDS = ["firstname", "lastname", "company", "address1", "address2", "city", "state", "zipcode", "country", "phone"]
+ADDRESS_FIELDS = [
+  "firstname",
+  "lastname",
+  "company",
+  "address1",
+  "address2",
+  "city",
+  "state",
+  "zipcode",
+  "country",
+  "phone"
+]
+
+Spree::PermittedAttributes.address_attributes << [
+  :user_id,
+  :deleted_at
+]


### PR DESCRIPTION
1. The permitted attributes override was never used inside the addresses controller
2. Now, it is possible to add additional address fields to permitted attributes.
