### PR TITLE
Adjust country select for bootstrap

### DIFF
--- a/app/views/spree/addresses/_form.html.erb
+++ b/app/views/spree/addresses/_form.html.erb
@@ -5,7 +5,7 @@
     <p class="form-group" id="<%= "#{address_id}country" %>">
       <%= address_form.label :country_id, Spree.t(:country) %><span class="required">*</span><br />
       <span id="<%= "#{address_id}country-selection" %>">
-        <%= address_form.collection_select :country_id, available_countries, :id, :name, {}, {:class => 'required'} %>
+        <%= address_form.collection_select :country_id, available_countries, :id, :name, {}, {:class => 'required form-control'} %>
       </span>
     </p>
   <% elsif field == "state" %>


### PR DESCRIPTION
This adds the bootstrap styling to the country select box in the address forms. Goodlooking!