### PR TITLE
Drop Spree Auth Devise dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,6 @@ source 'http://rubygems.org'
 
 gem 'spree', github: 'spree/spree', branch: 'master'
 gem 'spree_auth_devise', github: 'spree/spree_auth_devise', branch: 'master'
-
 gemspec
 
 group :test do

--- a/app/assets/javascripts/spree/frontend/spree_address_book.js.erb
+++ b/app/assets/javascripts/spree/frontend/spree_address_book.js.erb
@@ -1,5 +1,5 @@
 //= require spree/frontend
-//= require spree/frontend/spree_auth
+<% require_asset('spree/frontend/spree_auth') if (Object.const_get("Spree::User") rescue false) %>
 
 (function($) {
   $(document).ready(function(){

--- a/app/overrides/add_address_book_to_my_account.rb
+++ b/app/overrides/add_address_book_to_my_account.rb
@@ -1,7 +1,9 @@
-Deface::Override.new(
-  :virtual_path => "spree/users/show",
-  name: "address_book_account_my_orders",
-  :insert_after => "[data-hook='account_my_orders'], #account_my_orders[data-hook]",
-  :partial => "spree/users/addresses",
-  :disabled => false
-)
+if Object.const_defined?("Spree::User")
+  Deface::Override.new(
+    :virtual_path => "spree/users/show",
+    :name => "address_book_account_my_orders",
+    :insert_after => "[data-hook='account_my_orders'], #account_my_orders[data-hook]",
+    :partial => "spree/users/addresses",
+    :disabled => false
+  )
+end

--- a/app/overrides/add_address_book_to_my_account.rb
+++ b/app/overrides/add_address_book_to_my_account.rb
@@ -1,4 +1,4 @@
-if Object.const_defined?("Spree::User")
+if (Object.const_get("Spree::User") rescue false)
   Deface::Override.new(
     :virtual_path => "spree/users/show",
     :name => "address_book_account_my_orders",

--- a/spree_address_book.gemspec
+++ b/spree_address_book.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.requirements << 'none'
 
   s.add_dependency 'spree_core', '~> 3.1.0.beta'
-  s.add_dependency 'spree_auth_devise', '~> 3.1.0.beta'
+  s.add_development_dependency 'spree_auth_devise', '~> 3.1.0.beta'
 
   s.add_development_dependency 'rspec-rails', '~> 3.4.1'
   s.add_development_dependency 'sqlite3'


### PR DESCRIPTION
This PR allows using Address Book with applications that don't use Spree Auth Devise.