### PR TITLE
Set spree dependencies to >= 3.1.0 version

### DIFF
--- a/spree_address_book.gemspec
+++ b/spree_address_book.gemspec
@@ -14,8 +14,8 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.requirements << 'none'
 
-  s.add_dependency 'spree_core', '~> 3.2.0.alpha'
-  s.add_development_dependency 'spree_auth_devise', '~> 3.2.0.alpha'
+  s.add_dependency 'spree_core', '>= 3.1.0'
+  s.add_development_dependency 'spree_auth_devise', '>= 3.1.0'
 
   s.add_development_dependency 'rspec-rails', '~> 3.4.1'
   s.add_development_dependency 'sqlite3'

--- a/spree_address_book.gemspec
+++ b/spree_address_book.gemspec
@@ -14,8 +14,8 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.requirements << 'none'
 
-  s.add_dependency 'spree_core', '>= 3.1.0'
-  s.add_development_dependency 'spree_auth_devise', '>= 3.1.0'
+  s.add_dependency 'spree_core', '>= 3.1.0', '< 4.0'
+  s.add_development_dependency 'spree_auth_devise', '>= 3.1.0', '< 4.0'
 
   s.add_development_dependency 'rspec-rails', '~> 3.4.1'
   s.add_development_dependency 'sqlite3'


### PR DESCRIPTION
This PR changes the version of spree related gems that this extension depends on to `>= 3.1.0`.