### PR TITLE
Saved address to address book only if user ask to save it

### DIFF
--- a/app/controllers/spree/checkout_controller_decorator.rb
+++ b/app/controllers/spree/checkout_controller_decorator.rb
@@ -39,11 +39,11 @@ if defined?(Spree::Frontend)
       if @order.bill_address_id != @order.ship_address_id && bill_address.same_as?(ship_address)
         @order.update_column(:bill_address_id, ship_address.id)
         bill_address.destroy
-      else
+      elsif params[:save_user_address]
         bill_address.update_attribute(:user_id, spree_current_user.try(:id))
       end
 
-      ship_address.update_attribute(:user_id, spree_current_user.try(:id))
+      ship_address.update_attribute(:user_id, spree_current_user.try(:id)) if params[:save_user_address]
     end
   end
 end


### PR DESCRIPTION
Earlier it was saving all the addresses and ```save_user_address``` parameters not in used.

Address should be stored only if use provide permission to save