### PR TITLE
WIP: Addresses are getting duplicated

### DIFF
--- a/spec/features/checkout_address_selection_spec.rb
+++ b/spec/features/checkout_address_selection_spec.rb
@@ -315,5 +315,27 @@ describe 'Address selection during checkout', type: :feature do
         end.to_not change { user.addresses.count }
       end
     end
+
+    describe 'using the same address second time', js: true do
+      it 'should not duplicate the address' do
+        expect do
+          address = user.addresses.first
+
+          check 'order_use_billing'
+          within('#billing') do
+            choose "order_bill_address_id_#{address.id}"
+          end
+          complete_checkout
+
+          visit spree.root_path
+          click_link 'Ruby on Rails Mug'
+          click_button 'add-to-cart-button'
+
+          click_button 'Checkout'
+          find('#link-to-cart a').click
+          click_button 'Checkout'
+        end.to_not change { user.addresses.count }
+      end
+    end
   end
 end


### PR DESCRIPTION
Addresses are getting duplicated after reusing them on next checkouts. 

So far i can't do much about that but at least i've prepared a failing specs scenario which fails on spree 3.5 and 3.6.

Related to #128 