### PR TITLE
Added Deface as dependency

### DIFF
--- a/spree_address_book.gemspec
+++ b/spree_address_book.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |s|
   spree_version = '>= 3.2.0', '< 4.0'
   s.add_runtime_dependency 'spree_core', spree_version
   s.add_runtime_dependency 'spree_auth_devise', spree_version
+  s.add_dependency 'deface', '~> 1.0'
 
   s.add_development_dependency 'appraisal'
   s.add_development_dependency 'capybara'


### PR DESCRIPTION
Since Spree 4.0 [doesn't require deface](https://github.com/spree/spree/pull/9394) we need to require it here